### PR TITLE
Fixes makefile to create bin dir and adds pthread dep to utils building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.dll
 docs/output/*
 log
+bin/

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ override CFLAGS += $(OSFLAGS) $(BUILDFLAGS) -fPIC -O2
 
 # cppanim is an alias for src
 .PHONY: cppanim
-cppanim: src
+cppanim: dirs src
 
 debug: CFLAGS += -O0 -g
 debug: cleanso src
@@ -62,6 +62,9 @@ debug: cleanso src
 test: debug
 
 all: $(submodules)
+
+dirs: 
+	$(MKDIRCMD) $(bin_dir)
 
 # Utils are built with the library, hence the dependency
 utils: cppanim

--- a/utils/demos/Makefile
+++ b/utils/demos/Makefile
@@ -9,7 +9,7 @@ all: dirstruct $(binfiles)
 
 $(binfiles): $(objects)
 	$(CPP) -Wl,-rpath,. -o $@ \
-        $(addprefix $(objdir)/,$(addsuffix .o,$(@F))) -L$(bin_dir) -lcppanim
+        $(addprefix $(objdir)/,$(addsuffix .o,$(@F))) -L$(bin_dir) -lcppanim -lpthread
 
 .PHONY: dirstruct
 dirstruct:


### PR DESCRIPTION
Please accept my humble pr.

For my make and make all to work without errors I had to make sure that the bin dir was created and also add the linker option for the utils to have pthread.

Now it also works on my machine and may in the future work on your's.

This should fix and close the issue #1 